### PR TITLE
ci: switch OpenCode workflows to gpt-5.2-codex

### DIFF
--- a/.changeset/smart-otters-drum.md
+++ b/.changeset/smart-otters-drum.md
@@ -1,0 +1,5 @@
+---
+'@irvinebroque/http-rfc-utils': patch
+---
+
+Switch OpenCode issue workflows from `openai/gpt-5.3-codex` to `openai/gpt-5.2-codex` to avoid model access errors when using an OpenAI API key in GitHub Actions.

--- a/.github/workflows/opencode-issues-debug.yml
+++ b/.github/workflows/opencode-issues-debug.yml
@@ -10,7 +10,7 @@ on:
       model:
         description: Model in provider/model format
         required: false
-        default: openai/gpt-5.3-codex
+        default: openai/gpt-5.2-codex
         type: string
 
 concurrency:

--- a/.github/workflows/opencode-issues.yml
+++ b/.github/workflows/opencode-issues.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
-          model: openai/gpt-5.3-codex
+          model: openai/gpt-5.2-codex
           prompt: |
             You are working on a newly opened GitHub issue and should treat the issue itself as the task prompt.
 


### PR DESCRIPTION
## Summary
- switch OpenCode issue workflow model from `openai/gpt-5.3-codex` to `openai/gpt-5.2-codex`
- switch one-off debug workflow default model to `openai/gpt-5.2-codex`
- add a patch changeset documenting the model compatibility fix for API-key-based GitHub Actions runs

## Why
- the previous model selection fails with `model_not_found` for API key auth in CI
- `gpt-5.2-codex` avoids that access mismatch and restores issue automation