### PR TITLE
ci: pass GH_TOKEN to OpenCode issue workflows

### DIFF
--- a/.changeset/polite-spiders-shop.md
+++ b/.changeset/polite-spiders-shop.md
@@ -1,0 +1,5 @@
+---
+'@irvinebroque/http-rfc-utils': patch
+---
+
+Pass `GH_TOKEN` to OpenCode issue workflows so in-run `gh` commands can read issue context without requiring manual token setup.

--- a/.github/workflows/opencode-issues-debug.yml
+++ b/.github/workflows/opencode-issues-debug.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Run OpenCode with debug logging
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
           MODEL: ${{ github.event.inputs.model }}
           SHARE: 'false'
         run: opencode --print-logs --log-level DEBUG github run

--- a/.github/workflows/opencode-issues.yml
+++ b/.github/workflows/opencode-issues.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
         with:
           model: openai/gpt-5.2-codex
           prompt: |


### PR DESCRIPTION
## Summary
- pass `GH_TOKEN: ${{ github.token }}` to both OpenCode issue workflows so `gh` commands can access issue context during runs
- keep OIDC-based auth in place for the OpenCode action
- include a patch changeset for the workflow fix

## Changeset
- `.changeset/polite-spiders-shop.md`