### PR TITLE
ci: ensure OpenCode PRs link triggering issues

### DIFF
--- a/.changeset/calm-lobsters-beg.md
+++ b/.changeset/calm-lobsters-beg.md
@@ -1,0 +1,5 @@
+---
+'@irvinebroque/http-rfc-utils': patch
+---
+
+Ensure OpenCode issue workflows include explicit issue-closing references in generated pull requests, including a post-run safeguard in the debug workflow that appends `Closes #<issue>` when missing.

--- a/.github/workflows/opencode-issues-debug.yml
+++ b/.github/workflows/opencode-issues-debug.yml
@@ -75,13 +75,14 @@ jobs:
               printf '%s\n' "$issue_body"
               echo
               echo "research deeply"
-              echo "then write plan to markdown"
-              echo "then review your plan and improve it"
-              echo "then implement your plan"
-              echo "then review your implementation and improve it"
-              echo "when you are done commit and push and make a pull request"
-              echo "$delim"
-          } >> "$GITHUB_ENV"
+               echo "then write plan to markdown"
+               echo "then review your plan and improve it"
+               echo "then implement your plan"
+               echo "then review your implementation and improve it"
+               echo "when you are done commit and push and make a pull request"
+               echo "the pull request description must include: Closes #${{ github.event.inputs.issue_number }}"
+               echo "$delim"
+           } >> "$GITHUB_ENV"
 
       - name: Run OpenCode with debug logging
         env:
@@ -90,6 +91,35 @@ jobs:
           MODEL: ${{ github.event.inputs.model }}
           SHARE: 'false'
         run: opencode --print-logs --log-level DEBUG github run
+
+      - name: Ensure created PR links issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          issue_number='${{ github.event.inputs.issue_number }}'
+          current_branch="$(git branch --show-current)"
+          pr_number="$(gh pr list --repo '${{ github.repository }}' --head "$current_branch" --json number --jq 'if length > 0 then .[0].number else "" end')"
+
+          if [ -z "$pr_number" ]; then
+            echo "No PR found for branch $current_branch; skipping issue link update."
+            exit 0
+          fi
+
+          pr_body="$(gh pr view "$pr_number" --repo '${{ github.repository }}' --json body --jq .body)"
+          if [[ "$pr_body" == *"#${issue_number}"* ]]; then
+            echo "PR #$pr_number already references issue #$issue_number."
+            exit 0
+          fi
+
+          updated_body="$pr_body"
+          if [ -n "$updated_body" ]; then
+            updated_body="$updated_body\n\nCloses #${issue_number}"
+          else
+            updated_body="Closes #${issue_number}"
+          fi
+
+          gh pr edit "$pr_number" --repo '${{ github.repository }}' --body "$updated_body"
+          echo "Updated PR #$pr_number to include Closes #$issue_number."
 
       - name: Upload OpenCode logs
         if: always()

--- a/.github/workflows/opencode-issues.yml
+++ b/.github/workflows/opencode-issues.yml
@@ -64,4 +64,5 @@ jobs:
             then implement your plan
             then review your implementation and improve it
             when you are done commit and push and make a pull request
+            the pull request description must include: Closes #${{ github.event.issue.number }}
         run: opencode github run


### PR DESCRIPTION
## Summary
- update issue-driven OpenCode prompt guidance to explicitly require `Closes #<issue>` in generated PR descriptions
- add a post-run safeguard in `opencode-issues-debug` that locates the PR created from the run branch and appends `Closes #<issue>` when missing
- keep existing OpenCode execution path and permissions, while making issue linkage deterministic for workflow-dispatch debug runs

## Changeset
- `.changeset/calm-lobsters-beg.md`

## Validation
- `pnpm check:structure`