### PR TITLE
ci: auto-review and autofix github-actions PRs on open

### DIFF
--- a/.changeset/fair-mails-bow.md
+++ b/.changeset/fair-mails-bow.md
@@ -1,0 +1,5 @@
+---
+'@irvinebroque/http-rfc-utils': patch
+---
+
+Add a pull-request-opened OpenCode workflow for GitHub Actions-authored PRs that runs a high-thinking review pass focused on standards compliance and then applies fixes directly on the same PR branch.

--- a/.github/workflows/opencode-pr-review-autofix.yml
+++ b/.github/workflows/opencode-pr-review-autofix.yml
@@ -1,0 +1,93 @@
+name: opencode-pr-review-autofix
+
+on:
+  pull_request:
+    types: [opened]
+
+concurrency:
+  group: opencode-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-and-fix:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.pull_request.user.login == 'github-actions[bot]' || github.event.pull_request.user.login == 'app/github-actions')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout PR head branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Get OpenCode version
+        id: version
+        run: |
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${VERSION:-latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache OpenCode CLI
+        id: cache-opencode
+        uses: actions/cache@v4
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+      - name: Install OpenCode CLI
+        if: steps.cache-opencode.outputs.cache-hit != 'true'
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Add OpenCode to PATH
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
+      - name: Configure high thinking mode
+        run: |
+          mkdir -p "$HOME/.opencode"
+          cat > "$HOME/.opencode/opencode.json" <<'EOF'
+          {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+              "openai": {
+                "models": {
+                  "gpt-5.2-codex": {
+                    "options": {
+                      "reasoningEffort": "high"
+                    }
+                  }
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Run OpenCode review and autofix
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          MODEL: openai/gpt-5.2-codex
+          PROMPT: |
+            You are running on pull request #${{ github.event.pull_request.number }}.
+            PR URL: ${{ github.event.pull_request.html_url }}
+            PR title: ${{ github.event.pull_request.title }}
+            PR body:
+            ${{ github.event.pull_request.body || '(no PR body provided)' }}
+
+            Run /review first.
+            Use high thinking mode for this entire run.
+            Prioritize standards-compliance review quality for the standard/spec being implemented (for example RFC, W3C, SemVer, or related normative references in this repo).
+            Validate normative MUST/SHOULD behavior and implementation/test/doc alignment.
+
+            After review findings are identified, implement fixes on this same branch:
+            ${{ github.event.pull_request.head.ref }}
+
+            Commit and push fixes to this same branch.
+            Do not create a new branch.
+            Do not open a new pull request.
+        run: opencode github run

--- a/docs/plans/opencode-pr-review-autofix-on-open-plan-2026-02-17.md
+++ b/docs/plans/opencode-pr-review-autofix-on-open-plan-2026-02-17.md
@@ -1,0 +1,61 @@
+# OpenCode PR-Opened Review+Autofix Plan
+
+## Objective
+
+When a pull request is initially opened by `github-actions`, automatically run OpenCode to:
+
+1. Run a review pass (`/review`) with high thinking mode.
+2. Focus review quality on standards-compliance for the spec being implemented (RFC/W3C/etc.).
+3. Apply review findings by committing fixes back to the same PR branch.
+4. Avoid creating a second PR.
+
+## Constraints and assumptions
+
+- Trigger only on initial PR creation (`pull_request` `opened`).
+- Scope only to PRs authored by GitHub Actions bot(s), not all PRs.
+- Use existing OpenCode auth model already used in this repo (OIDC + `GH_TOKEN`).
+- Keep workflow non-interactive and deterministic.
+
+## Implementation plan
+
+1. Add a new workflow file dedicated to this automation (`.github/workflows/opencode-pr-review-autofix.yml`).
+2. Trigger only on `pull_request` with `types: [opened]`.
+3. Gate job execution to PRs opened by GitHub Actions identity:
+   - `github-actions[bot]` (plus compatibility fallback `app/github-actions`).
+4. Ensure the job checks out the PR head branch directly so fixes land on the same branch.
+5. Reuse the OpenCode CLI cache pattern already used elsewhere:
+   - detect latest OpenCode release tag;
+   - cache `~/.opencode/bin` by OS/arch/version;
+   - install on cache miss.
+6. Configure high thinking mode by writing a runner-local OpenCode config that sets:
+   - `provider.openai.models.gpt-5.2-codex.options.reasoningEffort = high`.
+7. Run OpenCode with a custom prompt that explicitly requires:
+   - execute `/review` first;
+   - evaluate standards compliance for the standard/spec implemented in the PR;
+   - implement findings on the same branch;
+   - commit and push to the same PR branch;
+   - do not open a new PR.
+8. Add a changeset documenting the new PR-open autoreview/autofix automation.
+9. Run structural check(s), then commit, push, and open PR.
+
+## Plan critique
+
+- **Risk: `/review` command interpretation**
+  - The GitHub workflow prompt can require `/review`, but OpenCode might still execute an equivalent internal review flow rather than literal slash-command syntax.
+  - Mitigation: keep both explicit `/review` wording and concrete expected outputs (findings + implemented fixes).
+
+- **Risk: model-option precedence**
+  - Runner-local config must override defaults predictably.
+  - Mitigation: set reasoning option in home OpenCode config (`~/.opencode/opencode.json`) so it is outside repo and not accidentally committed.
+
+- **Risk: bot identity mismatch**
+  - Different GitHub contexts can expose bot identity differently.
+  - Mitigation: include both `github-actions[bot]` and `app/github-actions` checks.
+
+- **Risk: unintended loop/retrigger**
+  - Pushing fixes could retrigger workflows.
+  - Mitigation: trigger only on `pull_request.opened`, not `synchronize`.
+
+- **Risk: PR already clean**
+  - No changes may be needed; run should still succeed.
+  - Mitigation: rely on OpenCode's no-op behavior when no fixes are required.


### PR DESCRIPTION
## Summary
- add a new PR-opened OpenCode workflow that runs only for pull requests authored by GitHub Actions identities and only on initial creation
- configure OpenCode to run review-first guidance with standards-compliance focus, then apply findings on the same PR branch and push fixes without opening another PR
- set runner-local OpenCode model options for `openai/gpt-5.2-codex` with high reasoning effort and include CLI cache/install parity with existing workflows
- include planning artifact and a patch changeset for the automation behavior

## Changeset
- `.changeset/fair-mails-bow.md`

## Validation
- `pnpm check:structure`