### PR TITLE
chore(ci): allow manual CI dispatch for bot PRs

### DIFF
--- a/.changeset/neat-peaches-rush.md
+++ b/.changeset/neat-peaches-rush.md
@@ -1,0 +1,5 @@
+---
+'@irvinebroque/http-rfc-utils': patch
+---
+
+Add a manual `workflow_dispatch` trigger to the CI workflow so checks can be started for bot-authored pull requests when automatic `pull_request` runs are suppressed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- add workflow dispatch to the CI workflow so it can be triggered manually
- keep existing push and pull request triggers unchanged
- add a changeset for CI-required release metadata